### PR TITLE
Allow `--at boot` as a special start value

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ arrow>=1.0.0
 click>=8.0
 click-didyoumean
 colorama; sys_platform == "win32"
+psutil
 requests

--- a/watson/cli.py
+++ b/watson/cli.py
@@ -7,6 +7,7 @@ from dateutil import tz
 from functools import reduce, wraps
 
 import arrow
+import psutil
 import click
 from click_didyoumean import DYMGroup
 
@@ -87,7 +88,10 @@ class DateTimeParamType(click.ParamType):
 
     def convert(self, value, param, ctx) -> arrow:
         if value:
-            date = self._parse_multiformat(value)
+            if value == 'boot':
+                date = datetime.datetime.fromtimestamp(psutil.boot_time())
+            else:
+                date = self._parse_multiformat(value)
             if date is None:
                 raise click.UsageError(
                     "Could not match value '{}' to any supported date format"
@@ -197,8 +201,8 @@ def _start(watson, project, tags, restart=False, start_at=None, gap=True):
 @cli.command()
 @click.option('--at', 'at_', type=DateTime, default=None,
               cls=MutuallyExclusiveOption, mutually_exclusive=['gap_'],
-              help=('Start frame at this time. Must be in '
-                    '(YYYY-MM-DDT)?HH:MM(:SS)? format.'))
+              help=('Start frame at this time. Must be in the format '
+                    '(YYYY-MM-DDT)?HH:MM(:SS)? or the special value `boot`.'))
 @click.option('-g/-G', '--gap/--no-gap', 'gap_', is_flag=True, default=True,
               cls=MutuallyExclusiveOption, mutually_exclusive=['at_'],
               help=("(Don't) leave gap between end time of previous project "


### PR DESCRIPTION
I often find myself wanting to start tracking work when I boot up my computer. However, sometimes I have to rush into a meeting or do something else that causes me to not immediately start a time frame.

In such a case, I usually look up the boot time later and use that to start the tracking at the correct time.

This patch allows for the special value `boot` to be used when starting a frame like this:

    watson start --at boot ...