### PR TITLE
Fix broken date-time value `boot`

### DIFF
--- a/watson/cli.py
+++ b/watson/cli.py
@@ -89,7 +89,7 @@ class DateTimeParamType(click.ParamType):
     def convert(self, value, param, ctx) -> arrow:
         if value:
             if value == 'boot':
-                date = datetime.datetime.fromtimestamp(psutil.boot_time())
+                date = arrow.Arrow.fromtimestamp(psutil.boot_time())
             else:
                 date = self._parse_multiformat(value)
             if date is None:


### PR DESCRIPTION
Using Python's `datetime` causes problems since watson is using Arrow for date/time functionality everywhere.
This patch just switches to arrow for parsing the boot time as well.